### PR TITLE
[WIP] Add WIP exploration notebook

### DIFF
--- a/notebooks/exploration.ipynb
+++ b/notebooks/exploration.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cea01d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from io import BytesIO\n",
+    "from pathlib import Path\n",
+    "from zipfile import ZipFile\n",
+    "\n",
+    "import requests\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "\n",
+    "# Widen pandas display options for exploration\n",
+    "pd.options.display.max_seq_items = 2000\n",
+    "pd.options.display.max_rows = 4000\n",
+    "pd.options.display.max_columns = 4000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a81d74f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RAW_DATA_FILENAME = \"CO2EmissionHDV_VehicleExtract_02062021\"\n",
+    "RAW_DATA_DOWNLOAD_URL = f\"https://discomap.eea.europa.eu/app/CO2HDV/{RAW_DATA_FILENAME}.zip\"\n",
+    "\n",
+    "DATA_DIR = Path(\"./data\")\n",
+    "RAW_DATA_PATH = DATA_DIR / f\"{RAW_DATA_FILENAME}.csv\"\n",
+    "\n",
+    "\n",
+    "## Ensure data file is present\n",
+    "if not os.path.exists(RAW_DATA_PATH):\n",
+    "    print(\"File not found. Fetching it now\")\n",
+    "    resp = requests.get(RAW_DATA_DOWNLOAD_URL).content\n",
+    "\n",
+    "    with ZipFile(BytesIO(resp)) as zipfile:\n",
+    "        zipfile.extract(f\"{RAW_DATA_FILENAME}.csv\", path=DATA_DIR)\n",
+    "\n",
+    "    print(\"File downloaded.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9326587a",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "This dataset contains OEM data and MS (Member state) data that has been joined together nivaely.\n",
+    "\n",
+    "The MS data has fewer columns prefixed with `MS`. \n",
+    "\n",
+    "#### Some of these are equivalent to the OEM fields:\n",
+    "- (MS_Mh, MS_Mh_msv, MS_Mk) => Make (Manufacturer????)\n",
+    "- MS_Electric => \n",
+    "- MS_Hybrid => HybridElectricHDV\n",
+    "- MS_FT => Engine_FuelType (With assumptions) \n",
+    "- MS_TechnPermMaxLadenMass (kg) => GrossVehicleMass_t (tonnes)\n",
+    "\n",
+    "#### Need more investigation\"\n",
+    "- MS_VehicleCategoryCode => LegislativeClass (????)\n",
+    "- Meta_MS_fileId => Meta_OEM_fileId (???)\n",
+    "\n",
+    "#### Related Columns:\n",
+    "- MS_NumberOfAxles === AxleConfiguration\n",
+    "\n",
+    "\n",
+    "#### Can Drop???\n",
+    "- MS_StageOfCompletionCode\n",
+    "- MS_CryptHashManufacturerRecord\n",
+    "\n",
+    "\n",
+    "#### TODO:\n",
+    "MS_Bw????  \n",
+    "MS_MaximumSpeed \n",
+    "MS_SpecificCO2Emissions\n",
+    "MS_AveragePayload\n",
+    "MS_RegistrationDate \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "857a6fc1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(RAW_DATA_PATH)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a896d36a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ms_pks = df[df[\"OEM_PK_Vehicle\"].isna()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff757701",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.groupby(\"Match\").size()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa6f3efa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ms_pks.isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07797ca4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This adds a notebook to get us started exploring the data.

TODO:
- Better understand the relationships in the data. In particular the inconsistencies with the `Match` column. There are:
-- ~260k matches between OEM and MS
-- ~1m MS_only (imports????)
-- ~90k OEM_only (exports????)

- Work on merging some of the MS columns into the OEM equivalent columns (using the positive matches)